### PR TITLE
Fix: Correct error string formatting

### DIFF
--- a/adapter/simulate/simulate.go
+++ b/adapter/simulate/simulate.go
@@ -91,7 +91,7 @@ func (s *Simulate) Commission() map[util.ContractType]map[string]int {
 
 func (s *Simulate) Connect(id string, auth string, token string) (string, error) {
 	if id != "simulate" || auth != "simulation" {
-		return "", errors.New("auth failed for user: %s, auth: %s")
+		return "", fmt.Errorf("auth failed for user: %s, auth: %s", id, auth)
 	}
 	return TOKEN, nil
 }

--- a/adapter/simulate/simulate.go
+++ b/adapter/simulate/simulate.go
@@ -64,7 +64,7 @@ func (s *Simulate) Reset() {
 func (s *Simulate) ClosePosition(id string, limit int) error {
 	p, exists := s.Positions[id]
 	if !exists {
-		return fmt.Errorf("PositionID: %s, Not found!", id)
+		return fmt.Errorf("positionID: %s, not found", id)
 	}
 	// take commission.. transfer value to cash.
 	commission := s.orderCommission(p.Order)
@@ -91,7 +91,7 @@ func (s *Simulate) Commission() map[util.ContractType]map[string]int {
 
 func (s *Simulate) Connect(id string, auth string, token string) (string, error) {
 	if id != "simulate" || auth != "simulation" {
-		return "", errors.New("Auth Failed for user: %s, auth: %s!")
+		return "", errors.New("auth failed for user: %s, auth: %s")
 	}
 	return TOKEN, nil
 }
@@ -102,22 +102,22 @@ func (s *Simulate) ContractMultiplier() map[util.ContractType]int {
 
 func (s *Simulate) Get(table string, key string) (interface{}, error) {
 	if s.Token != TOKEN {
-		return nil, errors.New("Bad Auth Token!")
+		return nil, errors.New("bad auth token")
 	}
 	if s.Tables[table] != 1 {
-		return nil, fmt.Errorf("Invalid table: %s! Choose from: %+v", table, s.Tables)
+		return nil, fmt.Errorf("invalid table: %s choose from: %+v", table, s.Tables)
 	}
 	switch table {
 	case "position":
 		p, exists := s.Positions[key]
 		if !exists {
-			return nil, fmt.Errorf("No Position found for key: %s!", key)
+			return nil, fmt.Errorf("no position found for key: %s", key)
 		}
 		return p, nil
 	case "order":
 		o, exists := s.Orders[key]
 		if !exists {
-			return nil, fmt.Errorf("No Order found for key: %s!", key)
+			return nil, fmt.Errorf("no order found for key: %s", key)
 		}
 		return o, nil
 	case "cash":
@@ -126,12 +126,12 @@ func (s *Simulate) Get(table string, key string) (interface{}, error) {
 		return s.Value, nil
 	}
 
-	return nil, fmt.Errorf("No data found for key: %s!", key)
+	return nil, fmt.Errorf("no data found for key: %s", key)
 }
 
 func (s *Simulate) GetBalances() (map[string]int, error) {
 	if s.Token != TOKEN {
-		return nil, errors.New("Bad Auth Token!")
+		return nil, errors.New("bad auth token")
 	}
 	// More complex api call and munging goes here.
 	return map[string]int{"cash": s.Cash, "value": s.Value}, nil
@@ -173,7 +173,7 @@ func (s *Simulate) GetOptions(symbol string, month string) ([]structs.Option, st
 
 func (s *Simulate) GetOrders(filter string) (map[string]structs.Order, error) {
 	if s.Token != TOKEN {
-		return nil, errors.New("Bad Auth Token!")
+		return nil, errors.New("bad auth token")
 	}
 	// More complex api call and munging goes here.
 	return s.Orders, nil
@@ -181,7 +181,7 @@ func (s *Simulate) GetOrders(filter string) (map[string]structs.Order, error) {
 
 func (s *Simulate) GetPositions() (map[string]structs.Position, error) {
 	if s.Token != TOKEN {
-		return nil, errors.New("Bad Auth Token!")
+		return nil, errors.New("bad auth token")
 	}
 	// More complex api call and munging goes here.
 	return s.Positions, nil
@@ -193,7 +193,7 @@ func (s *Simulate) orderCommission(o structs.Order) int {
 
 func (s *Simulate) SubmitOrder(order structs.Order) (string, error) {
 	if s.Token != TOKEN {
-		return "", errors.New("Bad Auth Token!")
+		return "", errors.New("bad auth token")
 	}
 	orderid := fmt.Sprintf("order-%d", rand.Intn(1000000))
 	order.Id = orderid

--- a/adapter/tdameritrade/tdameritrade.go
+++ b/adapter/tdameritrade/tdameritrade.go
@@ -201,15 +201,15 @@ func (s *TDAmeritrade) GetOptions(symbol string, expire string) ([]structs.Optio
 	result := TDAResponse{}
 	err = xml.Unmarshal(body, &result)
 	if err != nil {
-		return options, stock, fmt.Errorf("body: %s, err: %s", string(body), err)
+		return options, stock, fmt.Errorf("body: %s, err: %s", string(body), err.Error())
 	}
 	if result.Error != "" {
-		return options, stock, fmt.Errorf("API Response Error: " + result.Error)
+		return options, stock, fmt.Errorf("api response error: %s", result.Error)
 	}
 
 	stock = underlyingToStock(result.Underlying)
 	if stock.Symbol != symbol {
-		return options, stock, fmt.Errorf("Stock.symbol: '%s' != '%s'", stock.Symbol, symbol)
+		return options, stock, fmt.Errorf("stock.symbol: '%s' != '%s'", stock.Symbol, symbol)
 	}
 
 	for _, optionchain := range result.Underlying.OptionChains {
@@ -247,7 +247,7 @@ func (s *TDAmeritrade) GetOptions(symbol string, expire string) ([]structs.Optio
 	}
 
 	if len(options) < 6 {
-		return options, stock, fmt.Errorf("Received less than 6 options!")
+		return options, stock, fmt.Errorf("received less than 6 options")
 	}
 
 	return options, stock, nil

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -252,26 +252,26 @@ func (c *Collector) addMaximum(o structs.Option, s structs.Stock, timestamp int6
 	t, _ := time.Parse("20060102", o.Expiration)
 	expirationDistance := timestamp - t.Unix()
 	if expirationDistance < int64(-6*24*60*60) {
-		return fmt.Errorf("Further than 1 week from expiration. Distance: %d", expirationDistance)
+		return fmt.Errorf("further than 1 week from expiration. distance: %d", expirationDistance)
 	}
 	if expirationDistance > int64(1*24*60*60) {
-		return fmt.Errorf("Expiration past. Distance: %d", expirationDistance)
+		return fmt.Errorf("expiration past. distance: %d", expirationDistance)
 	}
 
 	// Filtering out uninteresting Options here.
 	if o.Ask <= 0 {
-		return fmt.Errorf("Not interested in options with Ask <= 0.")
+		return fmt.Errorf("not interested in options with ask <= 0")
 	}
 	// No idea how Volume could be negative, but not interested in finding out.
 	if o.Volume <= 0 {
-		return fmt.Errorf("Not interested in options with Volume <= 0.")
+		return fmt.Errorf("not interested in options with volume <= 0")
 	}
 	// Only want out-of-the-money options.
 	if o.Type == "c" && o.Strike < s.Bid {
-		return fmt.Errorf("Not interested in out-of-the-money options.")
+		return fmt.Errorf("not interested in out-of-the-money options")
 	}
 	if o.Type == "p" && o.Strike > s.Bid {
-		return fmt.Errorf("Not interested in out-of-the-money options.")
+		return fmt.Errorf("not interested in out-of-the-money options")
 	}
 
 	m := structs.Maximum{}
@@ -349,8 +349,8 @@ func (c *Collector) Collect(symbol string) error {
 	}
 
 	if time.Now().Weekday() == time.Saturday || time.Now().Weekday() == time.Sunday {
-		c.logError("Collect", "No need for Sat, Sun.")
-		return fmt.Errorf("No need for Sat, Sun.")
+		c.logError("Collect", "no need for sat, sun")
+		return fmt.Errorf("no need for sat, sun")
 	}
 	early := "13:28"
 	late := "21:02"
@@ -435,7 +435,7 @@ func (c *Collector) GetMaximum(utcTimestamp int64, symbol string) (structs.Maxim
 		err = <-message.reply
 		maximum, exists = c.maximum[utcTimestamp][symbol]
 		if !exists {
-			err = fmt.Errorf("Symbol: %s does not exist for timestamp: %d", symbol, utcTimestamp)
+			err = fmt.Errorf("symbol: %s does not exist for timestamp: %d", symbol, utcTimestamp)
 		}
 	}
 	return maximum, err
@@ -598,7 +598,7 @@ func (c *Collector) GetQuote(utcTimestamp int64, underlying string, symbol strin
 		err = <-message.reply
 		quote, exists = c.quote[utcTimestamp][symbol]
 		if !exists {
-			err = fmt.Errorf("Symbol: %s does not exist for timestamp: %d", symbol, utcTimestamp)
+			err = fmt.Errorf("symbol: %s does not exist for timestamp: %d", symbol, utcTimestamp)
 		}
 	}
 	return quote, err
@@ -990,7 +990,7 @@ func (c *Collector) updateOptionTarget(o structs.Option, utc_timestamp int64) er
 	hhmmss_in_seconds := utc_timestamp % int64(24*60*60)
 	near, distance := isNear(hhmmss_in_seconds, o.Time, 45)
 	if !near {
-		return fmt.Errorf("%f seconds is too far away.", distance)
+		return fmt.Errorf("%f seconds is too far away", distance)
 	}
 
 	utc_interval := getTenMinTimestamp(utc_timestamp)

--- a/collector/tools.go
+++ b/collector/tools.go
@@ -30,7 +30,7 @@ func Clean(root_dir string, date string) []error {
 	defer d.Close()
 	symbols, _ := d.Readdirnames(-1)
 	if len(symbols) == 0 {
-		errors = append(errors, fmt.Errorf("Nothing to clean!"))
+		errors = append(errors, fmt.Errorf("nothing to clean"))
 	}
 	for _, symbol := range symbols {
 		options_dir := data_dir + "/" + symbol + "/o"

--- a/money/money.go
+++ b/money/money.go
@@ -57,7 +57,7 @@ func (m *Money) getRandomAllotment() (a structs.Allotment, err error) {
 			amt := m.Total / 100
 			a = structs.Allotment{Amount: amt}
 			if amt <= 0 {
-				err = errors.New("not enough total value to connstruct allotment")
+				err = errors.New("not enough total value to construct allotment")
 			}
 		}
 	}()

--- a/money/money.go
+++ b/money/money.go
@@ -26,7 +26,7 @@ func (m *Money) Get() (structs.Allotment, error) {
 	m.get <- reply
 	allotment := <-reply
 	if allotment == (structs.Allotment{}) {
-		err = errors.New("No Allotments")
+		err = errors.New("no allotments")
 	}
 	return allotment, err
 }
@@ -57,7 +57,7 @@ func (m *Money) getRandomAllotment() (a structs.Allotment, err error) {
 			amt := m.Total / 100
 			a = structs.Allotment{Amount: amt}
 			if amt <= 0 {
-				err = errors.New("Not enough Total Value to connstruct allotment.")
+				err = errors.New("not enough total value to connstruct allotment")
 			}
 		}
 	}()

--- a/trader/trader.go
+++ b/trader/trader.go
@@ -326,7 +326,7 @@ func (t *Trader) constructOrder(po structs.ProtoOrder, allotment int) (structs.O
 		o.Maxcost = (o.Volume * o.Limitprice * t.multiplier[o.Type]) + (o.Volume * t.commission[o.Type]["unit"])
 	}
 	if o.Volume <= 0 {
-		return o, errors.New("Impossible order. Not enough Allotment to cover commission.")
+		return o, errors.New("impossible order. not enough allotment to cover commission")
 	}
 	return o, nil
 }

--- a/util/funcs/funcs.go
+++ b/util/funcs/funcs.go
@@ -73,7 +73,7 @@ func Decode(eo string, c interface{}, encodingOrder []string) error {
 
 	s := strings.Split(eo, ",")
 	if len(s) != len(encodingOrder) {
-		return fmt.Errorf("Expected %d Items.  Got %d Items.", len(encodingOrder), len(s))
+		return fmt.Errorf("expected %d items. got %d items", len(encodingOrder), len(s))
 	}
 	for idx, v := range s {
 		f := r.FieldByName(encodingOrder[idx])
@@ -122,7 +122,7 @@ func Encode(c interface{}, encodingOrder []string) (string, error) {
 		}
 	}
 	if strings.Count(eo[1:], ",")+1 != len(encodingOrder) {
-		return eo[1:], fmt.Errorf("Expected %d Items.  Got %d Items.", len(encodingOrder), strings.Count(eo[1:], ",")+1)
+		return eo[1:], fmt.Errorf("expected %d items. got %d items", len(encodingOrder), strings.Count(eo[1:], ",")+1)
 	}
 	return eo[1:], nil
 }


### PR DESCRIPTION
Standardized error string formatting according to ST1005:
- Error strings should not be capitalized.
- Error strings should not end with punctuation or newlines.